### PR TITLE
Update Camera.m

### DIFF
--- a/@Camera/Camera.m
+++ b/@Camera/Camera.m
@@ -718,7 +718,7 @@ classdef Camera < handle
                 c.T = Tc;
             end
             if ~isempty(c.h_visualize) && ishandle(c.h_visualize)
-                set(c.h_camera3D, 'Matrix', c.T);
+                set(c.h_visualize, 'Matrix', c.T);
             end
         end
 


### PR DESCRIPTION
I found some issues while trying to update the 3D drawing of the Camera Object. Apparently this was caused by the deprecated variable 'h_camera3D' which seemed to be replaced by 'h_visualize' in the last versions of the toolbox. Now I can change the camera pose T and the drawing is updated correctly.

Thanks for the toolbox, it's amazing :)
