### PR TITLE
Bug fix and improvements in distortion use.

### DIFF
--- a/@CentralCamera/estpose.m
+++ b/@CentralCamera/estpose.m
@@ -29,6 +29,9 @@
 
 function T = estpose(c, XYZ, uv)
 
+    if ~isempty(c.distortion)
+        uv = c.undistort(uv);
+    end
     [R, t] = efficient_pnp(XYZ', uv', c.K);
 
     T = [R t; 0 0 0 1];


### PR DESCRIPTION
Fixes bug in distortion. Homogeneous coordinates were used instead of euclian to compute pixel distances.
Includes the computation of distortion when projecting rays.
Includes a handy undistortion function to directly undistort pixel coordinates.
